### PR TITLE
Removes usage of numpy deprecated types (int and float)

### DIFF
--- a/src/level_set/anisotropy.py
+++ b/src/level_set/anisotropy.py
@@ -92,7 +92,7 @@ def find_angle(elt_ribbon, elt_tip, zr_vrtx_tip, a_tip, b_tip, c_tip, x_lft, y_l
     front line in the given tip elements.
     """
 
-    closest_tip_cell = np.zeros((len(elt_ribbon),), dtype=np.int)
+    closest_tip_cell = np.zeros((len(elt_ribbon),), dtype=int)
     dist_ribbon = np.zeros((len(elt_ribbon),), dtype=np.float64)
     alpha = np.zeros((len(elt_ribbon),), dtype=np.float64)
     for i in range(len(elt_ribbon)):
@@ -368,7 +368,7 @@ def construct_polygon(elt_tip, l_tip, alpha_tip, mesh, zero_vertex_tip):
     polygon = np.vstack({tuple(row) for row in polygon})
 
 
-    tip_smoothed = np.array([], dtype=np.int) # the cells containing the edges of polygon (giving the smoothed front)
+    tip_smoothed = np.array([], dtype=int) # the cells containing the edges of polygon (giving the smoothed front)
     smthed_tip_points_left = np.empty((0, 2), dtype=np.float64) #left points of the tip line in the new tip cells
     smthed_tip_points_rgt = np.empty((0, 2), dtype=np.float64) #right points of the tip line in the new tip cells
 
@@ -388,7 +388,7 @@ def construct_polygon(elt_tip, l_tip, alpha_tip, mesh, zero_vertex_tip):
             dist = (polygon[cell_pnt[0], 0] - polygon[cell_pnt, 0]) ** 2 + (polygon[cell_pnt[0], 1] - polygon[
                 cell_pnt, 1]) ** 2
             farthest = np.argmax(dist)
-            to_delete = np.array([], dtype=np.int)
+            to_delete = np.array([], dtype=int)
             for m in range(1, cell_pnt.size):
                 if m != farthest:
                     to_delete = np.append(to_delete, cell_pnt[m])
@@ -426,8 +426,8 @@ def construct_polygon(elt_tip, l_tip, alpha_tip, mesh, zero_vertex_tip):
     smthed_tip_lines_c[zero_angle] = -smthed_tip_points_rgt[zero_angle, 0]
 
     # find the left neighbor of the tip cells in the tip
-    tip_lft_neghb = np.zeros((len(tip_smoothed),), dtype=np.int)
-    tip_rgt_neghb = np.empty((len(tip_smoothed),), dtype=np.int)
+    tip_lft_neghb = np.zeros((len(tip_smoothed),), dtype=int)
+    tip_rgt_neghb = np.empty((len(tip_smoothed),), dtype=int)
     for i in range(len(tip_smoothed)):
         equal = smthed_tip_points_rgt == smthed_tip_points_left[i]
         left_nei = np.where(np.logical_and(equal[:, 0], equal[:, 1]))[0]

--- a/src/mesh_obj/mesh.py
+++ b/src/mesh_obj/mesh.py
@@ -204,7 +204,7 @@ class CartesianMesh:
         booleconnEdgesNodes = np.zeros([numberofedges, 1], dtype=int)
         connEdgesNodes = np.empty([numberofedges, 2], dtype=int)
         connElemEdges = np.empty([self.NumberOfElts, 4], dtype=int)
-        connEdgesElem = np.full([numberofedges, 2], np.nan, dtype=np.int)
+        connEdgesElem = np.full([numberofedges, 2], np.nan, dtype=int)
         connNodesEdges = np.full([self.NumberofNodes, 4], np.nan, dtype=int)
         connNodesElem = np.full([self.NumberofNodes, 4], np.nan, dtype=int)
         k = 0

--- a/src/systems/sol_sys_EHL.py
+++ b/src/systems/sol_sys_EHL.py
@@ -132,7 +132,7 @@ def sol_sys_EHL(Fr_lstTmStp, sim_properties, fluid_properties, mat_properties, i
             #             corr_ribb_flag = True
             #
             #         # make a list of the ind of corresponding ribbon (and to_impose) that are in neg
-            #         toImp_neg_rib = np.asarray([], dtype=np.int)
+            #         toImp_neg_rib = np.asarray([], dtype=int)
             #         for i, elem in enumerate(to_impose):
             #             if corr_ribbon_TI[i] in neg:
             #                 toImp_neg_rib = np.append(toImp_neg_rib, i)

--- a/src/time_step/ts_implicit_front/inj_extended_footprint.py
+++ b/src/time_step/ts_implicit_front/inj_extended_footprint.py
@@ -602,7 +602,7 @@ def injection_extended_footprint(w_k, Fr_lstTmStp, C, Boundary, timeStep, Qin, m
     Fr_kplus1.TarrvlZrVrtx[Fr_kplus1.EltTip[new_tip]] = Fr_kplus1.time - Fr_kplus1.l[new_tip] / Fr_kplus1.v[new_tip]
     Fr_kplus1.wHist = np.maximum(Fr_kplus1.w, Fr_lstTmStp.wHist)
     Fr_kplus1.closed = data[1]
-    tip_neg_rib = np.asarray([], dtype=np.int)
+    tip_neg_rib = np.asarray([], dtype=int)
     # adding tip cells with closed corresponding ribbon cells to the list of closed cells
     for i, elem in enumerate(Fr_kplus1.EltTip):
         if corr_ribbon[i] in Fr_kplus1.closed and elem not in Fr_kplus1.closed:

--- a/src/tip/volume_integral.py
+++ b/src/tip/volume_integral.py
@@ -614,13 +614,13 @@ def FindBracket_w(dist, Kprime, Eprime, muPrime, Cprime, Vel, regime):
                         * dist ** (5/8)
     wm = 2 ** (1 / 3) * 3 ** (5 / 6) * (Vel * muPrime / Eprime) ** (1/3) * dist ** (2/3)
 
-    if np.nanmin([wk, wmtld, wm]) > np.finfo(np.float).eps:
+    if np.nanmin([wk, wmtld, wm]) > np.finfo(float).eps:
         b = 0.95 * np.nanmin([wk, wmtld, wm])
         a = 1.05 * np.nanmax([wk, wmtld, wm])
-    elif np.nanmin([wmtld, wm]) > np.finfo(np.float).eps:
+    elif np.nanmin([wmtld, wm]) > np.finfo(float).eps:
         b = 0.95 * np.nanmin([wmtld, wm])
         a = 1.05 * np.nanmax([wmtld, wm])
-    elif np.nanmin([wk, wm]) > np.finfo(np.float).eps:
+    elif np.nanmin([wk, wm]) > np.finfo(float).eps:
         b = 0.95 * np.nanmin([wk, wm])
         a = 1.05 * np.nanmax([wk, wm])
     else:

--- a/src/utilities/postprocess_fracture.py
+++ b/src/utilities/postprocess_fracture.py
@@ -2004,7 +2004,7 @@ def get_velocity_slice(Solid, Fluid, Fr_list, initial_point, simProp, vel_direct
         else:
             fr_mesh = Fr_list[i].mesh
         # 1) get the coordinates of the points in the slices
-        vector_to_be_lost = np.zeros(fr_mesh.NumberOfElts,dtype=np.int)
+        vector_to_be_lost = np.zeros(fr_mesh.NumberOfElts,dtype=int)
         NotUsd_var_values, sampling_line_center, sampling_cells = get_fracture_variable_slice_cell_center(vector_to_be_lost,
                                                                                                             fr_mesh,
                                                                                                             point = initial_point,
@@ -2044,9 +2044,9 @@ def get_velocity_slice(Solid, Fluid, Fr_list, initial_point, simProp, vel_direct
         EltCrack_i = Fr_list[i].EltCrack
         fluid_vel_list_i = fluid_vel_list[i]
 
-        vector_to_be_lost1 = np.zeros(fr_mesh.NumberOfElts, dtype=np.float)
+        vector_to_be_lost1 = np.zeros(fr_mesh.NumberOfElts, dtype=float)
         vector_to_be_lost1[EltCrack_i] = fluid_vel_list_i[indx1,:]
-        vector_to_be_lost2 = np.zeros(fr_mesh.NumberOfElts, dtype=np.float)
+        vector_to_be_lost2 = np.zeros(fr_mesh.NumberOfElts, dtype=float)
         vector_to_be_lost2[EltCrack_i] = fluid_vel_list_i[indx2,:]
 
         fluid_vel_list_final_i = [None] * (len(vector_to_be_lost1[sampling_cells]) + len(vector_to_be_lost2[sampling_cells]))


### PR DESCRIPTION
Fixes dependency issue where latest `numpy` would not work with pyfrac, and installing an older version of it would unleash dependency hell on my computer. 
Deprecated numpy types are `np.int` and `np.float`